### PR TITLE
Fixed file paths in peg and exporter tests.

### DIFF
--- a/macropy/core/test/exporters/__init__.py
+++ b/macropy/core/test/exporters/__init__.py
@@ -5,6 +5,8 @@ pyc_cache_count = 0
 pyc_cache_macro_count = 0
 from macropy.core.exporters import NullExporter, PycExporter, SaveExporter
 
+THIS_FOLDER = os.path.dirname(__file__)
+
 class Tests(unittest.TestCase):
     def test_null_exporter(self):
         import pyc_cache
@@ -28,9 +30,11 @@ class Tests(unittest.TestCase):
         reload(pyc_cache)
         assert (pyc_cache_count, pyc_cache_macro_count) == (5, 3)
 
+        
+        cache_file = os.path.join(THIS_FOLDER, "pyc_cache.py")
         # unless you touch the file to bring its mtime up to that of the
         # stored .pyc, in which case the macro gets re-run too
-        f = open(__file__ + "/../pyc_cache.py", "a")
+        f = open(cache_file, "a")
         f.write(" ")
         f.close()
 
@@ -40,17 +44,18 @@ class Tests(unittest.TestCase):
         reload(pyc_cache)
         assert (pyc_cache_count, pyc_cache_macro_count) == (7, 4)
 
-        f = open(__file__ + "/../pyc_cache.py", "a")
+        f = open(cache_file, "a")
         f.write(" ")
         f.close()
 
         reload(pyc_cache)
-        assert (pyc_cache_count, pyc_cache_macro_count) == (8, 5)
+        assert (pyc_cache_count, pyc_cache_macro_count) == (8, 5), (pyc_cache_count, pyc_cache_macro_count)
 
     def test_save_exporter(self):
         import macropy
 
-        macropy.exporter = SaveExporter(__file__ + "/../exported", __file__ + "/..")
+        exported_folder = os.path.join(THIS_FOLDER, "exported")
+        macropy.exporter = SaveExporter(exported_folder, THIS_FOLDER)
 
         # the original code should work
         import save
@@ -62,4 +67,4 @@ class Tests(unittest.TestCase):
         import macropy.core.test.exporters.exported.save as save_exported
         assert save_exported.run() == 14
         import shutil
-        shutil.rmtree(__file__ + "/../exported")
+        shutil.rmtree(exported_folder)

--- a/macropy/test/peg.py
+++ b/macropy/test/peg.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from macropy.peg import macros, peg, Success, cut, ParseError
 
@@ -365,11 +366,14 @@ expected: '}'
 
 
         # full tests, taken from http://www.json.org/JSON_checker/
+        peg_json_folder = os.path.join(os.path.dirname(__file__), "peg_json")
         for i in range(1, 34):
             if i not in [18]: # skipping the "too much nesting" failure test
 
                 with self.assertRaises(ParseError):
-                    json_doc.parse(open(__file__ + "/../peg_json/fail%s.json" % i).read())
+                    path = os.path.join(peg_json_folder, "fail%s.json" % i)
+                    json_doc.parse(open(path).read())
 
         for i in [1, 2, 3]:
-            test(json_exp, open(__file__ + "/../peg_json/pass%s.json" % i).read())
+            path = os.path.join(peg_json_folder, "pass%s.json" % i)
+            test(json_exp, open(path).read())


### PR DESCRIPTION
Replaced paths in style of **file** + '../folder' ones gotten from os.path module, since those tests caused IOErrors for me. Also see #57.
