### PR TITLE
readme.md wasn't updated when file was moved

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1211,7 +1211,7 @@ Pretty neat! This full example of a JSON parser demonstrates what MacroPEG provi
 - An extremely clear PEG-like syntax
 - Extremely concise parser definitions
 
-Not bad for an implementation that spans [350 lines of code](macropy/experimental/peg.py)!
+Not bad for an implementation that spans [350 lines of code](macropy/peg.py)!
 
 Experimental Macros
 ===================


### PR DESCRIPTION
fix broken link in readme.md,
caused by file move in 7c419039d6851b8576a1e9fefb4b40f71441cf3f
