### PR TITLE
New base macro: d, for dictionary literal shorthand

### DIFF
--- a/macropy/core/macros.py
+++ b/macropy/core/macros.py
@@ -166,6 +166,13 @@ def expand_entire_ast(tree, src, bindings):
                     assert isinstance(new_tree, list), type(new_tree)
                     return macro_expand(new_tree)
 
+            if isinstance(tree, Call):
+                new_tree = expand_if_in_registry(tree.func, tree, [], expr_registry)
+
+                if new_tree:
+                    assert isinstance(new_tree, expr), type(new_tree)
+                    return macro_expand(new_tree)
+
             if isinstance(tree, Subscript) and type(tree.slice) is Index:
 
                 new_tree = expand_if_in_registry(tree.value, tree.slice.value, [], expr_registry)

--- a/macropy/d.py
+++ b/macropy/d.py
@@ -1,0 +1,15 @@
+"""Macro to allow for Coffeescript/ES6-style object literal shorthand via `d` function, a la
+  `d(name, age, other=thing) == {"name": name, "age": age, "other": thing}`
+"""
+
+from macropy.core.macros import *
+
+macros = Macros()
+
+
+@macros.expr
+def d(*args, **kw):
+    """ use in place of dict() to mix positional & keyword args) """
+    tree = kw["tree"]
+    keywordified_args = [keyword(arg.id, arg) for arg in tree.args]
+    return Call(Name('dict', Load()), [], tree.keywords + keywordified_args, None, None)


### PR DESCRIPTION
Adding support for CoffeeScript/ES6-style dictionaries in python.

### Example & Explanation
```python
name = "Bob"
age = 24

# traditional python ways
person = {"name": name, "age": age, "version": 1}
person2 = dict(name=name, age=age, version=2)
```

But in CoffeeScript, you can just do
```coffeescript
cs_person = {name, age, version: "cs"}
```
The feature is known as the **Object Literal Property Value Shorthand**, and is [coming to Javascript as of ES6](ariya.ofilabs.com/2013/02/es6-and-object-literal-property-value-shorthand.html) 

Now you can use it in python, too, with MacroPy.

```python
from macropy.d import macros, d

person3 = d(name, age, version=3)
> {"name": "Bob", "age": 24, version: 3}  
```

### Implementation
This was a bit of a pain to implement without MacroPy, since the Python call stack doesn't include the expressions passed, and `inspect` is slow.  

Even with MacroPy, without forking the project I'd need to use a lookup and a slice, a la
```python
d[dict(name, age, version=3)]
# or, and I thought this was clever
d[ct(name, age, version=3)]
```

I showed `d[ct` to an unbiased python programmer and they said versions 1/2 looked way cleaner and they'd probably not use it.  Fair enough.  So I needed to make d(...) work directly.

I ended up needing to fork and slightly modify MacroPy to support changing the syntax tree to support function calls. Hopefully this is an acceptable addition.