### PR TITLE
Update to handle the changes in ast.Call signature for Python 3.5

### DIFF
--- a/macropy/core/analysis.py
+++ b/macropy/core/analysis.py
@@ -24,8 +24,8 @@ def find_assignments(tree, collect, stop, **kw):
 def extract_arg_names(args):
     if PY3:
         return dict(
-            ([(args.vararg, args.vararg)] if args.vararg else []) +
-            ([(args.kwarg, args.kwarg)] if args.kwarg else []) +
+            ([(args.vararg.arg, args.vararg.arg)] if args.vararg else []) +
+            ([(args.kwarg.arg, args.kwarg.arg)] if args.kwarg else []) +
             [(arg.arg, Name(id=arg.arg, ctx=Param())) for arg in args.args]
         )
     else:

--- a/macropy/core/import_hooks.py
+++ b/macropy/core/import_hooks.py
@@ -11,6 +11,7 @@ from six import PY3
 if PY3:
     from importlib.machinery import PathFinder
     from types import ModuleType
+    import importlib.util
 
 
 class _MacroLoader(object):
@@ -79,6 +80,13 @@ it finds some."""
             file.close()
             file_path = file.name
         return source_code, file_path
+
+    def find_spec(self, module_name, package_path, target=None):
+        loader = self.find_module(module_name, package_path)
+        if loader:
+            return importlib.util.spec_from_loader(module_name, loader)
+        else:
+            return None
 
     def find_module(self, module_name, package_path):
         try:

--- a/macropy/core/quotes.py
+++ b/macropy/core/quotes.py
@@ -44,13 +44,19 @@ def q(tree, target, **kw):
 def u(tree):
     """Splices a value into the quoted code snippet, converting it into an AST
     via ast_repr"""
-    return Literal(Call(Name(id="ast_repr"), [tree], [], None, None))
+    if sys.version_info >= (3, 5):
+        return Literal(Call(Name(id="ast_repr"), [tree], []))
+    else:
+        return Literal(Call(Name(id="ast_repr"), [tree], [], None, None))
 
 
 @macro_stub
 def name(tree):
     "Splices a string value into the quoted code snippet as a Name"
-    return Literal(Call(Name(id="Name"), [], [keyword("id", tree)], None, None))
+    if sys.version_info >= (3, 5):
+        return Literal(Call(Name(id="Name"), [], [keyword("id", tree)]))
+    else:
+        return Literal(Call(Name(id="Name"), [], [keyword("id", tree)], None, None))
 
 
 @macro_stub
@@ -62,5 +68,8 @@ def ast(tree):
 @macro_stub
 def ast_list(tree):
     """Splices a list of ASTs into the quoted code snippet as a List node"""
-    return Literal(Call(Name(id="List"), [], [keyword("elts", tree)], None, None))
+    if sys.version_info >= (3, 5):
+        return Literal(Call(Name(id="List"), [], [keyword("elts", tree)]))
+    else:
+        return Literal(Call(Name(id="List"), [], [keyword("elts", tree)], None, None))
 

--- a/macropy/core/test/unparse.py
+++ b/macropy/core/test/unparse.py
@@ -189,7 +189,7 @@ with a as b:
         self.convert_test("\na.attr") # Attribute
         self.convert_test("""
 f()
-f(a, k=8, e=9, *b, **c)""") # Call
+f(a, *b, k=8, e=9, **c)""") # Call
         #self.convert_test("\n...") # Ellipsis
         self.convert_test("""
 a[1]

--- a/macropy/experimental/tco.py
+++ b/macropy/experimental/tco.py
@@ -77,7 +77,7 @@ def tco(tree, **kw):
                     args=args, 
                     starargs=starargs, 
                     kwargs=kwargs)):
-                if starargs:
+                if starargs and sys.version_info < (3, 5):
                     with hq as code:
                     # get rid of starargs
                         return (TcoCall,
@@ -104,7 +104,7 @@ def tco(tree, **kw):
                     args=args,
                     starargs=starargs,
                     kwargs=kwargs)):
-                if starargs:
+                if starargs and sys.version_info < (3, 5):
                     with hq as code:
                     # get rid of starargs
                         return (TcoIgnore,


### PR DESCRIPTION
This patch adds necessary checks to handle Python 3.5 ast.Call signature change. I have tested it in Python 3.6 by running the tests.