### PR TITLE
Add support for ternary conditional expression in tail call optimization

### DIFF
--- a/macropy/experimental/tco.py
+++ b/macropy/experimental/tco.py
@@ -102,6 +102,13 @@ def tco(tree, **kw):
                                 ast_literal[kwargs or ast.Dict([], [])])
 
                 return code
+            elif ast.Return(value=ast.IfExp(
+                        body=body,
+                        orelse=orelse,
+                        test=test)):
+                return ast.If(body=[ast.Return(value=body)],
+                              orelse=[ast.Return(value=orelse)],
+                              test=test)
             else:
                 return tree
 

--- a/macropy/experimental/test/tco.py
+++ b/macropy/experimental/test/tco.py
@@ -119,6 +119,12 @@ class Tests(unittest.TestCase):
 
         self.assertEquals(120, fact(5))
 
+    def test_tco_ternary(self):
+        @tco
+        def foo(n):
+            return 1 if n == 0 else foo(n-1)
+        self.assertEquals(1, foo(3000))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR enables tail call optimization for ternary conditional expression in return statement.
e.g
```python
@tco
def tail_rec(x, acc=0):
    return acc if len(x) == 0 else tail_rec(x[1:], acc + x[0])
```