### PR TITLE
Make MacroPy3 compatible with Python 3.11

### DIFF
--- a/macropy/case_classes.py
+++ b/macropy/case_classes.py
@@ -171,6 +171,7 @@ def prep_initialization(init_fun, args, vararg, kwarg, defaults, all_args):
     kws.update({
         'kwonlyargs': [],
         'kw_defaults': [],
+        'posonlyargs': [],
         'args': [ast.arg('self', None)] + [ast.arg(id, None) for id
                                            in args],
         'vararg': ast.arg(vararg, None) if vararg is not None else None,
@@ -235,7 +236,14 @@ def case_transform(tree, gen_sym, parents):
     tree.bases = parents
     assign = ast.FunctionDef(
         gen_sym("prepare_"+tree.name),
-        ast.arguments([], None, [], [], None, []),
+        ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[]),
         outer,
         [hq[apply]],
         None

--- a/macropy/core/failure.py
+++ b/macropy/core/failure.py
@@ -24,7 +24,7 @@ def clear_errors(tree, **kw):
         tb = "".join(traceback.format_tb(tree.__traceback__))
         msg = str(tree)
         if type(tree) is not AssertionError or tree.args == ():
-            msg = ("".join(tree.args) + "\nCaused by Macro-Expansion Error:\n" +
+            msg = ("".join(map(str, tree.args)) + "\nCaused by Macro-Expansion Error:\n" +
                    tb)
         return hq[raise_error(MacroExpansionError(msg))]
     else:

--- a/macropy/core/hquotes.py
+++ b/macropy/core/hquotes.py
@@ -132,8 +132,16 @@ def hygienator(tree, stop, scope, **kw):
         id, subtree = res
         if 'unhygienic' == id:
             stop()
-            tree.slice.value.ctx = None
-            return tree.slice.value
+            if isinstance(tree.slice, ast.Index):
+                # Python 3.8-
+                tree.slice.value.ctx = None
+                return tree.slice.value
+            elif isinstance(tree.slice, ast.expr):
+                # Python 3.9+
+                tree.slice.ctx = None
+                return tree.slice
+            else:
+                assert False, f'Wrong type: {type(tree.slice)}'
 
 
 macros.expose_unhygienic(ast)


### PR DESCRIPTION
I made changes to comply with the following runtime changes.

In Python 3.8+, lineno/col_offset became required, as part of the adoption of the peg_parser.

In Python 3.8+, arguments has a new parameter - posonlyargs.

The value of Subscript.slice was changed from Index to expr in Python 3.9 as part of the "Parental Scope References in Named Expressions" proposal (PEP 572).

With these changes tests don't actually pass, but they do fail, which is an improvement. Before, we couldn't even run the tests. I'm not sure to what degree these failures are the results of real problems vs just needing to fix up the tests in response to runtime changes.